### PR TITLE
Added lap export to CSV feature for stopwatch CLI

### DIFF
--- a/basic_programs/stopwatch_cli/README.md
+++ b/basic_programs/stopwatch_cli/README.md
@@ -7,6 +7,7 @@ A simple interactive stopwatch with laps.
 - Maintains state: `start_time`, `elapsed`, and `laps`
 - `start`: begins timing (idempotent)
 - `lap`: records current total elapsed time
+- `lap export`: writes laps to `laps.csv`
 - `stop`: freezes time and accumulates into `elapsed`
 - `reset`: clears time and laps
 - `exit`/`q`: prints final time and quits

--- a/basic_programs/stopwatch_cli/main.py
+++ b/basic_programs/stopwatch_cli/main.py
@@ -1,4 +1,5 @@
 import time
+import csv
 from typing import Optional
 
 from shared.cli_utils import create_repl_loop
@@ -30,6 +31,19 @@ def process_command(cmd: str, state: dict) -> None:
             current_elapsed = elapsed + (now - start_time)
             laps.append(current_elapsed)
             print(f"Lap {len(laps)}: {format_duration(current_elapsed)}")
+    elif cmd == "lap export":
+        if not laps:
+            print("No laps to export.")
+        else:
+            with open("laps.csv", "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerow(["Lap", "Total Time", "Duration"])
+                prev_total = 0.0
+                for i, total in enumerate(laps, 1):
+                    duration = total - prev_total
+                    writer.writerow([i, f"{total:.3f}", f"{duration:.3f}"])
+                    prev_total = total
+            print("Laps exported to laps.csv.")
     elif cmd == "stop":
         if start_time is None:
             print("Not running.")

--- a/laps.csv
+++ b/laps.csv
@@ -1,0 +1,2 @@
+Lap,Total Time,Duration
+1,2.960,2.960


### PR DESCRIPTION
Implements issue #3: Stopwatch lap export to CSV

- Added `lap export` command that writes lap data to [laps.csv](cci:7://file:///d:/Programming/Here-i-come-Python/laps.csv:0:0-0:0)
- CSV includes columns: Lap number, Total Time (seconds), Duration (seconds)
- Updated README.md to document the new command
- 
## Testing

- Tested lap recording and export functionality
- Verified CSV output format and data accuracy

